### PR TITLE
Add passing Comment model tests

### DIFF
--- a/comments/migrations/0001_initial.py
+++ b/comments/migrations/0001_initial.py
@@ -18,8 +18,21 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('text', models.TextField()),
                 ('created_on', models.DateTimeField(auto_now_add=True)),
-                ('created_by', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
-                ('parent', models.ForeignKey(null=True, to='comments.Comment')),
+                (
+                    'created_by',
+                    models.ForeignKey(
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
+                    ),
+                ),
+                (
+                    'parent',
+                    models.ForeignKey(
+                        null=True,
+                        to='comments.Comment',
+                        on_delete=models.CASCADE,
+                    ),
+                ),
             ],
             options={
                 'ordering': ['-id'],

--- a/comments/models.py
+++ b/comments/models.py
@@ -12,9 +12,11 @@ def find_fold(text):
 
 class Comment(models.Model):
     text = models.TextField()
-    created_by = models.ForeignKey(User)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     created_on = models.DateTimeField(auto_now_add=True)
-    parent = models.ForeignKey('Comment', null=True, blank=True, db_index=True)
+    parent = models.ForeignKey(
+        'Comment', null=True, blank=True, db_index=True, on_delete=models.CASCADE
+    )
     
     class Meta:
         ordering = ['-id']

--- a/comments/test_settings.py
+++ b/comments/test_settings.py
@@ -1,0 +1,9 @@
+SECRET_KEY='test'
+INSTALLED_APPS=[
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'comments',
+]
+DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}}
+USE_TZ=True
+DEFAULT_AUTO_FIELD='django.db.models.AutoField'

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -1,3 +1,54 @@
-from django.test import TestCase
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "comments.test_settings")
+import django
+django.setup()
 
-# Create your tests here.
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from .models import Comment, SUBJECT_LENGTH
+
+
+class TestCommentModel(TestCase):
+    """Tests for the :class:`Comment` model helper methods."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="tester")
+
+    def make_comment(self, text):
+        return Comment(text=text, created_by=self.user)
+
+    def test_subject_and_body_short_single_line(self):
+        """A short single line should be the subject and leave an empty body."""
+        comment = self.make_comment("Hello World")
+
+        self.assertEqual(comment.subject(), "Hello World")
+        self.assertEqual(comment.body(), "")
+
+    def test_subject_truncates_long_first_line(self):
+        """First line longer than SUBJECT_LENGTH is truncated with ellipsis."""
+        long_text = "A" * (SUBJECT_LENGTH + 10)
+        comment = self.make_comment(long_text)
+
+        self.assertEqual(
+            comment.subject(),
+            "A" * SUBJECT_LENGTH + "...",
+        )
+        self.assertEqual(comment.body(), "A" * 10)
+
+    def test_body_multiline(self):
+        """Body should contain text after a blank line separation."""
+        text = "Subject line\n\nBody line 1\nBody line 2"
+        comment = self.make_comment(text)
+
+        self.assertEqual(comment.subject(), "Subject line")
+        self.assertEqual(comment.body(), "Body line 1\nBody line 2")
+
+    def test_windows_line_endings(self):
+        """Windows newlines should be normalised when splitting."""
+        text = "Subject\r\n\r\nBody"
+        comment = self.make_comment(text)
+
+        self.assertEqual(comment.subject(), "Subject")
+        self.assertEqual(comment.body(), "Body")
+


### PR DESCRIPTION
## Summary
- add `on_delete` to Comment FK fields and migration
- configure Django settings for tests
- implement Django tests that validate `Comment.subject()` and `Comment.body()`

## Testing
- `pytest comments/tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68419a180f4c832aa6200be3330bcb61