### PR TITLE
Improve env script fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ $ cd K666
   $ docker-compose up [-d] [--build]
 ```
 
-### 2.2 Virtual Environment (depricated, works, uses sqlite3)
+### 2.2 Virtual Environment (deprecated, works, uses sqlite3)
+The `k666-env` helper creates a Python virtual environment and starts the
+development server. If `virtualenv` is not installed it will fall back to
+`python3 -m venv`.
 ```
 $ . ./k666-env
 ```
 
-This starts the server, it should start up ready.
+This starts the server and should be ready to use.
 
 ## 3. Visit the site.
 Go to http://localhost:8000/

--- a/k666-env
+++ b/k666-env
@@ -8,22 +8,26 @@
 # From: electrum/electrum-env
 # Modified: procrasti@k5-stats.org 13 Aug 2015
 
-PYTHON=python
+PYTHON=python3
 
 export DJANGO_SETTINGS_MODULE="k666.settings"
 export DEFAULT_DATABASE="sqlite3"
 export DEBUG=True
 
-if which virtualenv; then
-    if which ${PYTHON}; then
-        if ! [ -e ./env/bin/activate ]; then
-	        virtualenv env -p ${PYTHON}
+if which ${PYTHON}; then
+    if ! [ -e ./env/bin/activate ]; then
+        if which virtualenv; then
+            virtualenv env -p ${PYTHON}
+        else
+            echo "virtualenv not found, using built in venv"
+            ${PYTHON} -m venv env
         fi
+    fi
 
-        source ./env/bin/activate
-        pip install --upgrade 'pip<7' # We want this gone too! We need the latest version of pip that supports unzip.
-        python setup.py install
-        pip unzip django_messages # We want this gone!
+    source ./env/bin/activate
+    pip install --upgrade 'pip<7' # We want this gone too! We need the latest version of pip that supports unzip.
+    python setup.py install
+    pip unzip django_messages # We want this gone!
 
         # WHY DOESN'T THIS WORK FROM setup.py?
         # pip install django-recaptcha2
@@ -44,14 +48,10 @@ if which virtualenv; then
         fi
 
 
-        ./manage.py runserver "$@"
-        # deactivate
-    else
-        echo "You probably have to install ${PYTHON}"
-        echo "sudo apt-get install python3?"
-    fi
+    ./manage.py runserver "$@"
+    # deactivate
 else
-    echo "You probably have to install virtualenv."
-    echo "sudo apt-get install python-virtualenv?"
+    echo "You probably have to install ${PYTHON}"
+    echo "sudo apt-get install python3?"
 fi
 


### PR DESCRIPTION
## Summary
- improve k666-env to default to python3 and fall back to `python3 -m venv` when `virtualenv` isn't available
- document the new behaviour in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841a306e854832aaaa0e57726c5d497