### PR TITLE
Upgrade project to Django 5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,25 @@ This script sets the necessary environment variables and invokes the Django test
 
 Always run this script before committing changes to verify the tests pass.
 
+## Running the Development Server
+
+To manually start the application, you can either use Docker or the provided
+virtual environment helper. The easiest way is to run the helper script:
+
+```bash
+. ./k666-env
+```
+
+This creates a virtual environment (if one does not exist), installs the
+dependencies, runs migrations and then starts the Django development server at
+`http://localhost:8000/`.
+
+Alternatively, if you prefer Docker, ensure you have `docker-compose` installed
+and execute:
+
+```bash
+docker-compose up
+```
+
+Refer to the `README.md` for further details on these options.
+

--- a/comments/urls.py
+++ b/comments/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 
 from django.views.generic.base import RedirectView
 from django.views.generic.base import TemplateView
@@ -6,14 +6,14 @@ from django.views.generic.base import TemplateView
 from .views import list, story_list, story_detail, add, detail, reply, source, ajax_preview, ajax_add, ajax_comment_form
 
 urlpatterns = [
-    url(r'^list.html$', list, name="comment-list"),
-    url(r'^story_list.html$', story_list, name="story-list"),
-    url(r'^story/(?P<id>[0-9]+)$', story_detail, name="story-detail"),
-    url(r'^add.html$', add, name="add-comment"),
-    url(r'^comment/(?P<id>[0-9]+)$', detail, name="comment-detail"),
-    url(r'^reply/(?P<id>[0-9]+)$', reply, name="comment-reply"),
-    url(r'^source/(?P<id>[0-9]+)$', source, name="comment-source"),
-    url(r'^ajax_preview.html$', ajax_preview, name="ajax-preview-comment"),
-    url(r'^ajax_add.html$', ajax_add, name="ajax-add-comment"),
-    url(r'^ajax_comment_form.html$', ajax_comment_form, name="ajax-comment-form"),
+    re_path(r'^list.html$', list, name="comment-list"),
+    re_path(r'^story_list.html$', story_list, name="story-list"),
+    re_path(r'^story/(?P<id>[0-9]+)$', story_detail, name="story-detail"),
+    re_path(r'^add.html$', add, name="add-comment"),
+    re_path(r'^comment/(?P<id>[0-9]+)$', detail, name="comment-detail"),
+    re_path(r'^reply/(?P<id>[0-9]+)$', reply, name="comment-reply"),
+    re_path(r'^source/(?P<id>[0-9]+)$', source, name="comment-source"),
+    re_path(r'^ajax_preview.html$', ajax_preview, name="ajax-preview-comment"),
+    re_path(r'^ajax_add.html$', ajax_add, name="ajax-add-comment"),
+    re_path(r'^ajax_comment_form.html$', ajax_comment_form, name="ajax-comment-form"),
 ]

--- a/comments/views.py
+++ b/comments/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from django.http import HttpResponseRedirect, HttpResponse
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .models import Comment
 

--- a/freek666/templates/django_messages/base.html
+++ b/freek666/templates/django_messages/base.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load url from future %}
 {% block content %}
 {% endblock %}
 {% block sidebar %}

--- a/freek666/templates/django_messages/sidebar_menu.html
+++ b/freek666/templates/django_messages/sidebar_menu.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 
 <h2>Messages Menu</h2>
 <ul>

--- a/freek666/urls.py
+++ b/freek666/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from django.views.generic.base import RedirectView
 from django.views.generic.base import TemplateView
 
 urlpatterns = [
-    url(r'^index.html$', TemplateView.as_view(template_name="index.html")),
-    # url(r'^$', RedirectView.as_view(url="/index.html")),
+    path('index.html', TemplateView.as_view(template_name="index.html")),
+    # path(r'^$', RedirectView.as_view(url="/index.html")),
 ]

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -30,7 +30,7 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'comments',
     'freek666',
     'django.contrib.sites',
@@ -44,18 +44,18 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-)
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = 'k666.urls'
 
@@ -69,6 +69,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
                 ],
         },
     },
@@ -128,6 +129,8 @@ STATIC_URL = '/static/'
 SITE_ID = 1
 
 LOGIN_REDIRECT_URL = '/'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 AUTHENTICATION_BACKENDS = (
     

--- a/k666/urls.py
+++ b/k666/urls.py
@@ -5,25 +5,25 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 from django.contrib import admin
 
 import comments
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^', include('freek666.urls')),
-    url(r'^accounts/', include('allauth.urls')),
-    url(r'^messages/', include('django_messages.urls')),
-    url(r'^comments/', include('comments.urls')),
-    url(r'^$', comments.views.story_list ),
+    path('admin/', admin.site.urls),
+    path('', include('freek666.urls')),
+    path('accounts/', include('allauth.urls')),
+    path('messages/', include('django_messages.urls')),
+    path('comments/', include('comments.urls')),
+    path('', comments.views.story_list ),
     
 ]


### PR DESCRIPTION
## Summary
- update settings for Django 5
- convert URL config to `path`/`re_path`
- modernize views imports
- fix templates that loaded deprecated `url` tag
- add instructions for running a dev server
- tests still pass

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842a2b1ecac832a9abb6b4c6146c872