### PR TITLE
Add manual server helper and TODO list

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+- Replace deprecated `django_messages` package with a Django 5 compatible fork.
+- Fix `k666-env` script so it no longer downgrades pip.
+- Add Docker instructions for local development.
+

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -37,7 +37,10 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-    'django_messages',
+# 'django_messages' is disabled for now due to incompatibility with
+# Django 5.x. Once a compatible version is available this can be
+# re-enabled.
+# 'django_messages',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/k666/urls.py
+++ b/k666/urls.py
@@ -22,7 +22,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('freek666.urls')),
     path('accounts/', include('allauth.urls')),
-    path('messages/', include('django_messages.urls')),
+    # Temporary disable django_messages until a compatible release is available
+    # path('messages/', include('django_messages.urls')),
     path('comments/', include('comments.urls')),
     path('', comments.views.story_list ),
     

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Simple helper to run the dev server without the broken k666-env
+
+export DJANGO_SETTINGS_MODULE=k666.settings
+export DEFAULT_DATABASE=sqlite3
+export DEBUG=True
+
+python manage.py migrate --noinput
+exec python manage.py runserver "$@"


### PR DESCRIPTION
## Summary
- disable `django_messages` app and URL imports for Django 5 compatibility
- add `start_server.sh` helper for running the dev server without the broken env script
- create `TODO.md` for informal notes

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`
- `python manage.py migrate`
- `python manage.py runserver 0.0.0.0:8000` *(served index.html)*

------
https://chatgpt.com/codex/tasks/task_e_6842a7cec03c832a94637ddc389514c7