### PR TITLE
Refactor Comment.replies query

### DIFF
--- a/comments/models.py
+++ b/comments/models.py
@@ -72,9 +72,18 @@ class Comment(models.Model):
         return ""
     
     def replies(self):
+        """Return the total number of descendant comments."""
+        if not self.pk:
+            return 0
+
         total = 0
-        for comment in self.comment_set.all():
-            total += 1 + comment.replies()
+        parents = [self.pk]
+        while parents:
+            children = list(
+                Comment.objects.filter(parent_id__in=parents).values_list("id", flat=True)
+            )
+            total += len(children)
+            parents = children
         return total
 
     def __str__(self):

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -54,6 +54,22 @@ class TestCommentModel(TestCase):
         self.assertEqual(comment.subject(), "Subject")
         self.assertEqual(comment.body(), "Body")
 
+    def test_replies_counts_descendants(self):
+        """`replies` should count all descendant comments."""
+        root = Comment.objects.create(text="root", created_by=self.user)
+        child1 = Comment.objects.create(text="c1", created_by=self.user, parent=root)
+        child2 = Comment.objects.create(text="c2", created_by=self.user, parent=root)
+        Comment.objects.create(text="gc", created_by=self.user, parent=child1)
+
+        self.assertEqual(root.replies(), 3)
+        self.assertEqual(child1.replies(), 1)
+        self.assertEqual(child2.replies(), 0)
+
+    def test_replies_unsaved_comment(self):
+        """Unsaved comments have no replies."""
+        comment = self.make_comment("temp")
+        self.assertEqual(comment.replies(), 0)
+
 
 class TestAjaxEndpoints(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- optimize `Comment.replies` to avoid recursive queries
- add unit tests for reply counting

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842cf090874832a833e493f09276d38