### PR TITLE
Switch to django-user-messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ $ cd K666
 $ pip install -r requirements.txt
 ```
 
+The project now uses the `django-user-messages` package, a maintained fork of
+`django_messages` compatible with Django 5.
+
 ## 2. Start the Development Server
 Run the helper script which installs dependencies, applies migrations and launches the server on port 8000.
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # TODO
 
-- Replace deprecated `django_messages` package with a Django 5 compatible fork.
 - Fix `k666-env` script so it no longer downgrades pip.
 - Add Docker instructions for local development.
 

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -38,10 +38,8 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-# 'django_messages' is disabled for now due to incompatibility with
-# Django 5.x. Once a compatible version is available this can be
-# re-enabled.
-# 'django_messages',
+# django-user-messages provides Django 5 compatible private messaging
+    'user_messages',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django
 django-allauth
-django-messages
+django-user-messages

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires=[
         "Django>=3.2",
         "django-allauth",
-        "django-messages",
+        "django-user-messages",
     ],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- depend on django-user-messages instead of the abandoned django-messages
- document the new dependency
- remove outdated TODO item
- update settings to use `user_messages`

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842d33b829c832aac22c07e75c479e3