### PR TITLE
Enable user_messages

### DIFF
--- a/freek666/templates/fragments/common_links_fragment.html
+++ b/freek666/templates/fragments/common_links_fragment.html
@@ -1,6 +1,6 @@
 <div>
     {% if user.is_authenticated %}
-        [<a href="/messages/">Messages</a> / <a href="/messages/compose">Compose</a>]
+        [<a href="{% url 'messages_inbox' %}">Messages</a> / <a href="{% url 'messages_compose' %}">Compose</a>]
         [<a href="/admin">Admin</a>]
         [<a href="/accounts/profile/">Profile</a>]
         [<a href="{% url 'account_email' %}">Change E-mail</a>]

--- a/freek666/templates/fragments/message_sidebar_box.html
+++ b/freek666/templates/fragments/message_sidebar_box.html
@@ -1,2 +1,2 @@
 <h2>Messages</h2>
-[<a href="/messages/">Messages</a> / <a href="/messages/compose">Compose</a>]
+[<a href="{% url 'messages_inbox' %}">Messages</a> / <a href="{% url 'messages_compose' %}">Compose</a>]

--- a/freek666/templates/user_messages/compose.html
+++ b/freek666/templates/user_messages/compose.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Compose Message</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Send</button>
+</form>
+{% endblock %}

--- a/freek666/templates/user_messages/inbox.html
+++ b/freek666/templates/user_messages/inbox.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Messages</h1>
+<ul>
+{% for message in messages_list %}
+  <li class="{{ message.tags }}">{{ message }}</li>
+{% empty %}
+  <li>No messages.</li>
+{% endfor %}
+</ul>
+<p><a href="{% url 'messages_compose' %}">Compose</a></p>
+{% endblock %}

--- a/freek666/views.py
+++ b/freek666/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.shortcuts import redirect, render
+from django import forms
+
+from user_messages import api as user_messages_api
+
+
+class ComposeForm(forms.Form):
+    to = forms.ModelChoiceField(queryset=User.objects.all(), label="To")
+    message = forms.CharField(widget=forms.Textarea, label="Message")
+
+
+@login_required
+def message_inbox(request):
+    messages_list = user_messages_api.get_messages(request=request)
+    return render(request, "user_messages/inbox.html", {"messages_list": messages_list})
+
+
+@login_required
+def message_compose(request):
+    if request.method == "POST":
+        form = ComposeForm(request.POST)
+        if form.is_valid():
+            user_messages_api.info(
+                form.cleaned_data["to"],
+                form.cleaned_data["message"],
+            )
+            messages.success(request, "Message sent")
+            return redirect("messages_inbox")
+    else:
+        form = ComposeForm()
+    return render(request, "user_messages/compose.html", {"form": form})
 
 # Create your views here.

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -72,6 +72,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'user_messages.context_processors.messages',
                 ],
         },
     },

--- a/k666/urls.py
+++ b/k666/urls.py
@@ -13,8 +13,10 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
-from django.urls import include, path, re_path
+from django.urls import include, path
 from django.contrib import admin
+
+import freek666.views as freek_views
 
 import comments
 
@@ -22,8 +24,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('freek666.urls')),
     path('accounts/', include('allauth.urls')),
-    # Temporary disable django_messages until a compatible release is available
-    # path('messages/', include('django_messages.urls')),
+    path('messages/', freek_views.message_inbox, name='messages_inbox'),
+    path('messages/compose', freek_views.message_compose, name='messages_compose'),
     path('comments/', include('comments.urls')),
     path('', comments.views.story_list ),
     


### PR DESCRIPTION
## Summary
- hook up django-user-messages
- add inbox and compose views
- wire new URLs
- show message links in templates

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842d61fabf4832a855680d1d2d5ce5a