### PR TITLE
Add user messages integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 ./runalltests.sh
 ```
 
-This script sets the necessary environment variables and invokes the Django test suite for the `comments` app. It requires Python dependencies from `requirements.txt` to be installed.
+This script sets the necessary environment variables and invokes the Django test suite for the `comments` and `freek666` apps. It requires Python dependencies from `requirements.txt` to be installed.
 
 Always run this script before committing changes to verify the tests pass.
 

--- a/comments/test_settings.py
+++ b/comments/test_settings.py
@@ -1,5 +1,6 @@
 SECRET_KEY='test'
 INSTALLED_APPS=[
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -7,6 +8,10 @@ INSTALLED_APPS=[
     'django.contrib.staticfiles',
     'freek666',
     'comments',
+    'user_messages',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
 ]
 MIDDLEWARE=[
     'django.middleware.security.SecurityMiddleware',
@@ -15,9 +20,10 @@ MIDDLEWARE=[
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
 ]
-ROOT_URLCONF='comments.urls'
-TEMPLATES=[{'BACKEND':'django.template.backends.django.DjangoTemplates','APP_DIRS':True,'OPTIONS':{'context_processors':['django.template.context_processors.request','django.contrib.auth.context_processors.auth','django.contrib.messages.context_processors.messages']}}]
+ROOT_URLCONF='comments.test_urls'
+TEMPLATES=[{'BACKEND':'django.template.backends.django.DjangoTemplates','APP_DIRS':True,'OPTIONS':{'context_processors':['django.template.context_processors.request','django.contrib.auth.context_processors.auth','django.contrib.messages.context_processors.messages','user_messages.context_processors.messages']}}]
 DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}}
 USE_TZ=True
 DEFAULT_AUTO_FIELD='django.db.models.AutoField'

--- a/comments/test_urls.py
+++ b/comments/test_urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from django.urls import include
+import freek666.views as freek_views
+from . import urls as comment_urls
+
+urlpatterns = [
+    path('messages/', freek_views.message_inbox, name='messages_inbox'),
+    path('messages/compose', freek_views.message_compose, name='messages_compose'),
+    path('accounts/', include('allauth.urls')),
+]
+urlpatterns += comment_urls.urlpatterns

--- a/freek666/tests.py
+++ b/freek666/tests.py
@@ -1,3 +1,37 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from user_messages.models import Message
 
-# Create your tests here.
+
+class UserMessagesTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.sender = User.objects.create_user(username="sender", password="pass")
+        self.receiver = User.objects.create_user(username="receiver", password="pass")
+
+    def test_compose_and_inbox_flow(self):
+        self.client.login(username="sender", password="pass")
+        response = self.client.post(
+            reverse("messages_compose"),
+            {"to": self.receiver.id, "message": "hello"},
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse("messages_inbox"))
+        success_messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn("Message sent", success_messages)
+
+        self.assertEqual(Message.objects.count(), 1)
+        msg = Message.objects.get()
+        self.assertEqual(msg.user, self.receiver)
+        self.assertEqual(msg.message, "hello")
+        self.assertIsNone(msg.delivered_at)
+
+        self.client.logout()
+        self.client.login(username="receiver", password="pass")
+        inbox = self.client.get(reverse("messages_inbox"))
+        self.assertContains(inbox, "hello")
+        msg.refresh_from_db()
+        self.assertIsNotNone(msg.delivered_at)

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Simple script to run the project's test suite.
-# Currently only the `comments` app has tests.
+# Currently the `comments` and `freek666` apps have tests.
 
 export DJANGO_SETTINGS_MODULE=comments.test_settings
 export DEFAULT_DATABASE=sqlite3
 export DEBUG=1
 
-python manage.py test comments
+python manage.py test comments freek666


### PR DESCRIPTION
## Summary
- expand AGENTS instructions to mention freek666 tests
- extend test settings with apps and middleware needed for messaging
- add combined URL config for running tests
- update test runner script to include freek666 tests
- implement message flow test

## Testing
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842d8c8fbf0832a82408081c810c2e2