### PR TITLE
Use env var for SECRET_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example SECRET_KEY generated with Django's utility:
+#   python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
+#SECRET_KEY="^_bk5wj9el+un48)*jyeva_482cky7ap1p)djrk6a8qr7v()@$"
+SECRET_KEY=changeme

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ $ pip install -r requirements.txt
 The project now uses the `django-user-messages` package, a maintained fork of
 `django_messages` compatible with Django 5.
 
+### Configure Environment Variables
+Copy `.env.example` to `.env` and adjust values as needed. At minimum set
+`SECRET_KEY` to a unique string. The example file contains a commented-out
+sample key that was generated with Django's `get_random_secret_key` utility:
+
+```bash
+cp .env.example .env
+echo "SECRET_KEY=your-production-key" >> .env
+```
+To generate a new value run:
+
+```bash
+python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
+```
+These variables are loaded by the helper scripts when starting the server or
+running tests.
+
 ## 2. Start the Development Server
 Run the helper script which applies migrations and launches the server on port 8000. Ensure dependencies are installed first using `pip install -r requirements.txt`.
 ```

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -20,7 +20,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '^_bk5wj9el+un48)*jyeva_482cky7ap1p)djrk6a8qr7v()@$'
+# Allow overriding via environment variable so secrets aren't stored in code.
+SECRET_KEY = os.environ.get('SECRET_KEY', 'changeme')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # Default to False if the environment variable is not set.

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -6,5 +6,6 @@
 export DJANGO_SETTINGS_MODULE=comments.test_settings
 export DEFAULT_DATABASE=sqlite3
 export DEBUG=1
+export SECRET_KEY=dev-secret-key
 
 python manage.py test comments freek666

--- a/start_server.sh
+++ b/start_server.sh
@@ -4,6 +4,7 @@
 export DJANGO_SETTINGS_MODULE=k666.settings
 export DEFAULT_DATABASE=sqlite3
 export DEBUG=True
+export SECRET_KEY=dev-secret-key
 
 python manage.py migrate --noinput
 exec python manage.py runserver "$@"


### PR DESCRIPTION
## Summary
- load SECRET_KEY from the environment
- expose SECRET_KEY in helper scripts for dev
- document .env setup in README
- add .env.example for local configuration
- keep original key as comment and note how to generate one

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842e134396c832abd2f6d4a9f47be1f