### PR TITLE
Add admin access test

### DIFF
--- a/comments/test_settings.py
+++ b/comments/test_settings.py
@@ -27,3 +27,4 @@ TEMPLATES=[{'BACKEND':'django.template.backends.django.DjangoTemplates','APP_DIR
 DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}}
 USE_TZ=True
 DEFAULT_AUTO_FIELD='django.db.models.AutoField'
+STATIC_URL='/static/'

--- a/comments/test_urls.py
+++ b/comments/test_urls.py
@@ -1,5 +1,5 @@
-from django.urls import path
-from django.urls import include
+from django.urls import include, path
+from django.contrib import admin
 import freek666.views as freek_views
 from . import urls as comment_urls
 
@@ -7,5 +7,6 @@ urlpatterns = [
     path('messages/', freek_views.message_inbox, name='messages_inbox'),
     path('messages/compose', freek_views.message_compose, name='messages_compose'),
     path('accounts/', include('allauth.urls')),
+    path('admin/', admin.site.urls),
 ]
 urlpatterns += comment_urls.urlpatterns

--- a/freek666/tests.py
+++ b/freek666/tests.py
@@ -70,3 +70,21 @@ class AuthFlowTests(TestCase):
         )
         self.user.refresh_from_db()
         self.assertEqual(self.user.email, 'new@example.com')
+
+
+class AdminAccessTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="pass",
+        )
+
+    def test_admin_index_accessible(self):
+        self.assertTrue(
+            self.client.login(username="admin", password="pass")
+        )
+        response = self.client.get(reverse("admin:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Django administration")


### PR DESCRIPTION
## Summary
- create AdminAccessTests to verify admin login
- enable admin URLs in test configuration
- set STATIC_URL for admin templates

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842f87902b4832aba5e1de63091fe90