### PR TITLE
Fix AJAX comment form validation

### DIFF
--- a/comments/forms.py
+++ b/comments/forms.py
@@ -14,3 +14,11 @@ class CommentForm(forms.Form):
         except Comment.DoesNotExist:
             raise forms.ValidationError("Invalid parent comment")
 
+
+class CommentFormOptionalText(CommentForm):
+    """Variant of :class:`CommentForm` where ``comment_text`` is optional."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["comment_text"].required = False
+

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -102,7 +102,13 @@ class TestAjaxEndpoints(TestCase):
     def test_ajax_comment_form(self):
         response = self.post("ajax-comment-form", {"comment_text": "text"})
         self.assertEqual(response.status_code, 200)
-        self.assertIn("textarea", response.json()["html"]) 
+        self.assertIn("textarea", response.json()["html"])
+
+    def test_ajax_comment_form_allows_empty_text(self):
+        """The comment form endpoint should accept empty text."""
+        response = self.post("ajax-comment-form", {"comment_text": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("textarea", response.json()["html"])
 
     def test_ajax_add_validation(self):
         response = self.post("ajax-add-comment", {})

--- a/comments/views.py
+++ b/comments/views.py
@@ -84,15 +84,25 @@ import logging
 from django.views.decorators.csrf import csrf_protect
 from django.template.loader import get_template
 from django.http import HttpResponseBadRequest
-from .forms import CommentForm
+from .forms import CommentForm, CommentFormOptionalText
 
 logger = logging.getLogger(__name__)
 
 @csrf_protect
 def ajax_comment_form(request):
-    form = CommentForm(request.POST)
+    """Return a comment form fragment via AJAX.
+
+    Unlike :func:`ajax_add`, this endpoint is used to fetch the form markup
+    before the user has typed anything.  Accept an empty ``comment_text`` value
+    by using :class:`CommentFormOptionalText`.
+    """
+
+    form = CommentFormOptionalText(request.POST)
     if not form.is_valid():
-        return HttpResponseBadRequest(json.dumps({'errors': form.errors}), content_type="application/json")
+        return HttpResponseBadRequest(
+            json.dumps({'errors': form.errors}),
+            content_type="application/json",
+        )
 
     template = get_template("comments/fragments/comment_form.html")
     comment = Comment(


### PR DESCRIPTION
## Summary
- allow comment text to be optional when fetching the AJAX form
- document in views why comment text is optional
- add regression test for empty comment text

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68443f1e788c832abdb469caff125298