### PR TITLE
Fix private messages disappearing

### DIFF
--- a/comments/test_settings.py
+++ b/comments/test_settings.py
@@ -23,7 +23,7 @@ MIDDLEWARE=[
     'allauth.account.middleware.AccountMiddleware',
 ]
 ROOT_URLCONF='comments.test_urls'
-TEMPLATES=[{'BACKEND':'django.template.backends.django.DjangoTemplates','APP_DIRS':True,'OPTIONS':{'context_processors':['django.template.context_processors.request','django.contrib.auth.context_processors.auth','django.contrib.messages.context_processors.messages','user_messages.context_processors.messages']}}]
+TEMPLATES=[{'BACKEND':'django.template.backends.django.DjangoTemplates','APP_DIRS':True,'OPTIONS':{'context_processors':['django.template.context_processors.request','django.contrib.auth.context_processors.auth','django.contrib.messages.context_processors.messages']}}]
 DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}}
 USE_TZ=True
 DEFAULT_AUTO_FIELD='django.db.models.AutoField'

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -73,7 +73,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'user_messages.context_processors.messages',
                 ],
         },
     },


### PR DESCRIPTION
## Summary
- stop injecting user inbox messages into every page by default

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68446385d32c832aad94297c5d9dc1ee