### PR TITLE
Use arneb django-messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ $ cd K666
 $ pip install -r requirements.txt
 ```
 
-The project now uses the `django-user-messages` package, a maintained fork of
-`django_messages` compatible with Django 5.
+The project uses the `django-messages` package from arneb patched for Django 5 compatibility.
 
 ### Configure Environment Variables
 Copy `.env.example` to `.env` and adjust values as needed. At minimum set

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django
 django-allauth
-django-messages @ git+https://github.com/procrasti/django-messages.git
+django-messages @ git+https://github.com/arneb/django-messages.git

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires=[
         "Django>=3.2",
         "django-allauth",
-        "django-user-messages",
+        "django-messages",
     ],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- switch dependency to arneb/django-messages
- update README to mention patched django-messages
- update setup.py dependency

## Testing
- `pip install -r requirements.txt`
- `./setup_messages.sh`
- `./runalltests.sh`
- `./start_server.sh` *(verified with curl)*

------
https://chatgpt.com/codex/tasks/task_e_6844706388a0832a84080a9107e602af