### PR TITLE
Add automated dev server check

### DIFF
--- a/runalltests.sh
+++ b/runalltests.sh
@@ -8,4 +8,7 @@ export DEFAULT_DATABASE=sqlite3
 export DEBUG=1
 export SECRET_KEY=dev-secret-key
 
-python manage.py test comments freek666
+python manage.py test comments freek666 || exit 1
+
+# Basic check that the development server starts correctly
+python test_server.py || exit 1

--- a/test_server.py
+++ b/test_server.py
@@ -1,0 +1,39 @@
+import subprocess
+import time
+import urllib.request
+import sys
+import os
+
+
+def main():
+    # Start the development server on port 8001 without autoreload
+    proc = subprocess.Popen(
+        ['./start_server.sh', '8001', '--noreload'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        # Wait for the server to become responsive
+        url = 'http://127.0.0.1:8001/'
+        for _ in range(20):
+            time.sleep(1)
+            try:
+                with urllib.request.urlopen(url) as resp:
+                    if resp.status == 200:
+                        print('Server responded with status 200')
+                        return 0
+            except Exception:
+                pass
+        print('Server did not respond in time')
+        return 1
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- create `test_server.py` to launch `start_server.sh` and verify response
- call the server test from `runalltests.sh`

## Testing
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684479716270832aa29be97e8fef3696