### PR TITLE
Switch to patched django-messages fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ $ cd K666
 $ pip install -r requirements.txt
 ```
 
-The project uses the `django-messages` package from arneb patched for Django 5 compatibility.
+The project uses the `django-messages` package from the `solve-coagulate` fork,
+which includes Django 5 compatibility fixes.
 
 ### Configure Environment Variables
 Copy `.env.example` to `.env` and adjust values as needed. At minimum set

--- a/k666/settings.py
+++ b/k666/settings.py
@@ -39,7 +39,7 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-# django-messages is used for private messaging (patched for Django 5)
+# django-messages is used for private messaging
     'django_messages',
     'django.contrib.admin',
     'django.contrib.auth',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django
 django-allauth
-django-messages @ git+https://github.com/arneb/django-messages.git
+django-messages @ git+https://github.com/solve-coagulate/django-messages.git


### PR DESCRIPTION
## Summary
- install `django-messages` from the `solve-coagulate` fork
- mention new dependency in the README
- update settings comment now that patch script isn't required

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844793365f4832a9feee81bada0a270