### PR TITLE
Switch to django_messages views

### DIFF
--- a/comments/test_urls.py
+++ b/comments/test_urls.py
@@ -1,11 +1,9 @@
 from django.urls import include, path
 from django.contrib import admin
-import freek666.views as freek_views
 from . import urls as comment_urls
 
 urlpatterns = [
-    path('messages/', freek_views.message_inbox, name='messages_inbox'),
-    path('messages/compose', freek_views.message_compose, name='messages_compose'),
+    path('messages/', include('django_messages.urls')),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/freek666/tests.py
+++ b/freek666/tests.py
@@ -15,13 +15,17 @@ class UserMessagesTests(TestCase):
         self.client.login(username="sender", password="pass")
         response = self.client.post(
             reverse("messages_compose"),
-            {"to": self.receiver.id, "message": "hello"},
+            {
+                "recipient": self.receiver.username,
+                "subject": "Hello",
+                "body": "hello",
+            },
             follow=True,
         )
 
         self.assertRedirects(response, reverse("messages_inbox"))
         success_messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("Message sent", success_messages)
+        self.assertIn("Message successfully sent.", success_messages)
 
         self.assertEqual(Message.objects.count(), 1)
         msg = Message.objects.get()
@@ -32,7 +36,7 @@ class UserMessagesTests(TestCase):
         self.client.logout()
         self.client.login(username="receiver", password="pass")
         inbox = self.client.get(reverse("messages_inbox"))
-        self.assertContains(inbox, "(no subject)")
+        self.assertContains(inbox, "Hello")
         msg.refresh_from_db()
         self.assertIsNone(msg.read_at)
 

--- a/k666/urls.py
+++ b/k666/urls.py
@@ -16,16 +16,13 @@ Including another URLconf
 from django.urls import include, path
 from django.contrib import admin
 
-import freek666.views as freek_views
-
 import comments
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('freek666.urls')),
     path('accounts/', include('allauth.urls')),
-    path('messages/', freek_views.message_inbox, name='messages_inbox'),
-    path('messages/compose', freek_views.message_compose, name='messages_compose'),
+    path('messages/', include('django_messages.urls')),
     path('comments/', include('comments.urls')),
     path('', comments.views.story_list ),
     


### PR DESCRIPTION
## Summary
- integrate django_messages URL routes
- update tests to match new compose form and success text

## Testing
- `pip install -r requirements.txt`
- `./setup_messages.sh`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684489d3e578832ab103cd3c2fd1223d