### PR TITLE
Fix vote arrow state updates

### DIFF
--- a/comments/models.py
+++ b/comments/models.py
@@ -96,6 +96,13 @@ class Comment(models.Model):
         agg = self.votes.aggregate(total=models.Sum("value"))
         return agg["total"] or 0
 
+    def user_vote(self, user):
+        """Return the value of ``user``'s moderation vote or ``None``."""
+        if not self.pk or not user.is_authenticated:
+            return None
+        vote = self.votes.filter(user=user).first()
+        return vote.value if vote else None
+
 
 class ModerationVote(models.Model):
     """Record a user's moderation vote on a comment."""

--- a/comments/static/js/ajax_comments.js
+++ b/comments/static/js/ajax_comments.js
@@ -199,6 +199,17 @@ function vote(comment_id, value) {
             if (score_el) {
                 score_el.textContent = json.score;
             }
+            var up_el = document.getElementById("upvote-" + comment_id);
+            var down_el = document.getElementById("downvote-" + comment_id);
+            if (up_el && down_el) {
+                if (value > 0) {
+                    up_el.src = "/static/images/up.jpg";
+                    down_el.src = "/static/images/downgrey.jpg";
+                } else {
+                    up_el.src = "/static/images/upgrey.jpg";
+                    down_el.src = "/static/images/down.jpg";
+                }
+            }
         },
         error: function(xhr, status, error) {
             alert("Vote failed: " + error);

--- a/comments/templates/comments/fragments/moderation.html
+++ b/comments/templates/comments/fragments/moderation.html
@@ -1,13 +1,14 @@
-{% load static %}
+{% load static comment_extras %}
 
+{% user_vote comment request.user as vote %}
 <div class="moderation">
     <div>
-        <img src="{% static 'images/upgrey.jpg' %}" width="20px" onclick="return vote({{ comment.id }}, 1);"/>
+        <img id="upvote-{{ comment.id }}" src="{% static 'images/' %}{% if vote == 1 %}up.jpg{% else %}upgrey.jpg{% endif %}" width="20px" onclick="return vote({{ comment.id }}, 1);"/>
     </div>
     <div class="modscore" id="modscore-{{ comment.id }}">
         {{ comment.mod_score }}
     </div>
     <div>
-        <img src="{% static 'images/downgrey.jpg' %}" width="20px" onclick="return vote({{ comment.id }}, -1);"/>
+        <img id="downvote-{{ comment.id }}" src="{% static 'images/' %}{% if vote == -1 %}down.jpg{% else %}downgrey.jpg{% endif %}" width="20px" onclick="return vote({{ comment.id }}, -1);"/>
     </div>
 </div>

--- a/comments/templatetags/comment_extras.py
+++ b/comments/templatetags/comment_extras.py
@@ -1,0 +1,8 @@
+from django import template
+from ..models import Comment
+
+register = template.Library()
+
+@register.simple_tag
+def user_vote(comment: Comment, user):
+    return comment.user_vote(user)

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -208,10 +208,30 @@ class ModerationVoteTests(TestCase):
 
     def test_moderation_template_displays_score(self):
         ModerationVote.objects.create(comment=self.comment, user=self.other, value=1)
+        from django.test.client import RequestFactory
         from django.template.loader import render_to_string
+        request = RequestFactory().get("/")
+        request.user = self.other
         html = render_to_string(
             "comments/fragments/moderation.html",
             {"comment": self.comment},
+            request=request,
         )
         self.assertIn(f'id="modscore-{self.comment.id}"', html)
         self.assertIn("1", html)
+
+    def test_moderation_template_highlights_user_vote(self):
+        ModerationVote.objects.create(comment=self.comment, user=self.user, value=1)
+        from django.test.client import RequestFactory
+        from django.template.loader import render_to_string
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = self.user
+        html = render_to_string(
+            "comments/fragments/moderation.html",
+            {"comment": self.comment},
+            request=request,
+        )
+        self.assertIn('id="upvote-{}"'.format(self.comment.id), html)
+        self.assertIn('/static/images/up.jpg', html)
+        self.assertIn('/static/images/downgrey.jpg', html)


### PR DESCRIPTION
## Summary
- add `user_vote` helper on `Comment`
- update moderation template to highlight a user's vote
- update JS to swap arrow images after voting
- expose `user_vote` template tag
- test moderation highlighting

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844b13c041c832ab87748d25fdb0d8f