### PR TITLE
Register moderation vote admin

### DIFF
--- a/comments/admin.py
+++ b/comments/admin.py
@@ -1,6 +1,15 @@
 from django.contrib import admin
-from .models import Comment
+from .models import Comment, ModerationVote
 
 admin.site.register(Comment)
+
+
+class ModerationVoteAdmin(admin.ModelAdmin):
+    list_display = ("comment", "user", "value", "created_on")
+    list_filter = ("value", "created_on")
+    search_fields = ("comment__text", "user__username")
+
+
+admin.site.register(ModerationVote, ModerationVoteAdmin)
 
 # Register your models here.

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -235,3 +235,11 @@ class ModerationVoteTests(TestCase):
         self.assertIn('id="upvote-{}"'.format(self.comment.id), html)
         self.assertIn('/static/images/up.jpg', html)
         self.assertIn('/static/images/downgrey.jpg', html)
+
+
+class AdminRegistrationTests(TestCase):
+    def test_moderation_vote_registered(self):
+        from django.contrib import admin
+        from comments.models import ModerationVote
+
+        self.assertIn(ModerationVote, admin.site._registry)


### PR DESCRIPTION
## Summary
- add ModerationVote admin registration
- test that ModerationVote is registered with the admin site

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844b9b4e984832a8f7379347304e27e