### PR TITLE
Add link to user list

### DIFF
--- a/comments/test_urls.py
+++ b/comments/test_urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('messages/', include('django_messages.urls')),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
+    path('', include('freek666.urls')),
 ]
 urlpatterns += comment_urls.urlpatterns

--- a/freek666/templates/fragments/sidebar.html
+++ b/freek666/templates/fragments/sidebar.html
@@ -22,11 +22,12 @@
     </div>
 {% endif %}
 <div class="box">
-    <h2>Other Links</h2>    
+    <h2>Other Links</h2>
     [<a href="/static/index.html">Static Index</a>]
     [<a href="/index.html">Old Index</a>]
-    [<a href="{% url 'story-list' %}">Stories</a>]        
-    [<a href="{% url 'comment-list' %}">Comments</a>]        
+    [<a href="{% url 'story-list' %}">Stories</a>]
+    [<a href="{% url 'comment-list' %}">Comments</a>]
+    [<a href="{% url 'user_list' %}">Users</a>]
 </div>
 {% if user.is_staff %}
     <div class="box">

--- a/freek666/tests.py
+++ b/freek666/tests.py
@@ -92,3 +92,20 @@ class AdminAccessTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Django administration")
+
+
+class UserListViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user1 = User.objects.create_user(username="alpha")
+        self.user2 = User.objects.create_user(username="beta")
+
+    def test_user_list_view_lists_users(self):
+        resp = self.client.get(reverse("user_list"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, self.user1.username)
+        self.assertContains(resp, self.user2.username)
+
+    def test_homepage_links_to_user_list(self):
+        resp = self.client.get(reverse("story-list"))
+        self.assertContains(resp, reverse("user_list"))


### PR DESCRIPTION
## Summary
- link the user list from the sidebar so it’s visible on the front page
- expose freek666 URLs in the test URL configuration
- test that user list page works and homepage links to it

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844c347e7b4832a9655d2394862f886