### PR TITLE
Fix comment count in story view

### DIFF
--- a/comments/templates/stories/story_detail.html
+++ b/comments/templates/stories/story_detail.html
@@ -9,7 +9,7 @@
 {% block full_width_content %}
     <div class="story_info">
         <a class="light" href="{% url 'story-detail' id=comment.id %}">{{comment.subject}}</a> | 
-        <b>6</b> comments (0 hidden) | 
+        <b>{{ comment.replies }}</b> comments (0 hidden) |
         <b><a href="{% if comment.id %}{% url "comment-reply" comment.id %}{% else %}#{% endif %}" onclick="return ajax_reply('{{comment.id}}');">Post A Comment</a></b>
     </div>
     

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -129,6 +129,15 @@ class StoryViewTests(TestCase):
         self.assertEqual(detail.status_code, 200)
         self.assertContains(detail, story.subject())
 
+    def test_story_detail_displays_comment_count(self):
+        """Story detail page should show the correct number of replies."""
+        story = Comment.objects.create(text="Subject\n\nBody", created_by=self.user)
+        Comment.objects.create(text="c1", created_by=self.user, parent=story)
+        Comment.objects.create(text="c2", created_by=self.user, parent=story)
+        detail = self.client.get(reverse('story-detail', args=[story.id]))
+        self.assertEqual(detail.status_code, 200)
+        self.assertContains(detail, "2 comments")
+
     def test_user_signup_flow(self):
         resp = self.client.post(reverse('account_signup'), {
             'username': 'newuser',


### PR DESCRIPTION
## Summary
- show accurate comment count on story page
- test that story detail displays correct count

## Testing
- `pip install -r requirements.txt`
- `./runalltests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68474cb817d8832a9827434f65364b12